### PR TITLE
Add stream-video command for simulator video streaming

### DIFF
--- a/Sources/AXe/Utilities/BridgeQueues.swift
+++ b/Sources/AXe/Utilities/BridgeQueues.swift
@@ -25,4 +25,7 @@ public enum BridgeQueues {
   /// ```
   ///
   public static let miscEventReaderQueue = DispatchQueue(label: "com.axe.miscellaneous.reader", qos: .userInitiated, attributes: .concurrent)
+  
+  /// Dedicated serial queue for video streaming operations to prevent race conditions
+  public static let videoStreamQueue = DispatchQueue(label: "com.axe.video.stream", qos: .userInitiated)
 } 

--- a/Sources/AXe/main.swift
+++ b/Sources/AXe/main.swift
@@ -23,7 +23,8 @@ struct Axe: AsyncParsableCommand {
             Key.self, 
             KeySequence.self, 
             Touch.self,
-            Gesture.self
+            Gesture.self,
+            StreamVideo.self
         ]
     )
 }

--- a/test-runner.sh
+++ b/test-runner.sh
@@ -63,6 +63,7 @@ show_usage() {
     echo "  ButtonTests         Run only button tests"
     echo "  GestureTests        Run only gesture tests"
     echo "  ListSimulatorsTests Run only list simulators tests"
+    echo "  StreamVideoTests    Run only stream video tests"
     echo ""
     echo "Examples:"
     echo "  $0                  # Build everything and run all tests"
@@ -106,7 +107,7 @@ while [[ $# -gt 0 ]]; do
             VERBOSE=true
             shift
             ;;
-        SwipeTests|TapTests|KeyTests|TouchTests|TypeTests|ButtonTests|GestureTests|ListSimulatorsTests)
+        SwipeTests|TapTests|KeyTests|TouchTests|TypeTests|ButtonTests|GestureTests|ListSimulatorsTests|StreamVideoTests)
             TEST_FILTER="$1"
             shift
             ;;


### PR DESCRIPTION
## Summary

This PR adds a new `stream-video` command to AXe that enables video streaming from iOS simulators to stdout using FBSimulatorControl.

## Features

- 🎥 Stream simulator screen video data directly to stdout
- 🎨 Support for multiple formats: H264, MJPEG, BGRA, Minicap  
- ⚙️ Configurable options: FPS, quality, scale, bitrate, key frame interval
- 🚀 Modern Swift async/await implementation with proper cancellation
- 📝 Comprehensive documentation of known limitations

## Current Status

Due to issues with FBSimulatorControl and iOS Simulator APIs:
- ✅ **BGRA format**: Working - outputs raw uncompressed pixel data
- ❌ **H264/MJPEG/Minicap**: Not working - no output due to encoding issues

## Usage

```bash
# Stream raw BGRA video data (working)
axe stream-video --udid <SIMULATOR_UDID> --format bgra --fps 10

# Convert to MP4 in real-time with ffmpeg
axe stream-video --format bgra --fps 10 | ffmpeg -f rawvideo -pixel_format bgra -video_size 393x852 -i - output.mp4
```

## Implementation Details

The command uses FBSimulatorControl's internal APIs (same as Meta's idb) rather than `xcrun simctl`. This provides:
- Direct access to the simulator's framebuffer
- Raw pixel data streaming capability
- More control over the streaming process

## Known Issues

1. Apple removed stdout support from `xcrun simctl io recordVideo`
2. FBSimulatorControl has unresolved video encoding issues (see facebook/idb#787, #841)
3. Only raw BGRA format currently produces output

## Alternatives Documented

The command includes warnings and suggests alternatives:
- Using `xcrun simctl io recordVideo output.mp4` for file recording
- Screen recording software like OBS for live streaming
- Example scripts demonstrating both working and non-working scenarios

## Testing

- Comprehensive test suite that verifies BGRA streaming works
- Tests document expected failures for compressed formats
- All tests pass with current implementation

## Files Changed

- `Sources/AXe/Commands/StreamVideo.swift` - Main command implementation
- `Sources/AXe/Utilities/BridgeQueues.swift` - Added video stream queue
- `Tests/StreamVideoTests.swift` - Comprehensive test suite
- `Tests/StreamVideoDebugTest.swift` - Debug test for streaming
- `examples/stream-video-*.sh` - Example usage scripts
- Updated command registration in `main.swift`
- Updated `test-runner.sh` to include StreamVideoTests